### PR TITLE
Add a second argument to specify the base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ $ ln -s "$(pwd)/branj" ~/bin/branj
 
 ## Usage
 
+```shell
+$ branj <jira-ticket-number> [<base-branch>]
+```
+
 A wizard will walk you through configuration of the script the first time it is executed.
 
 ### Options

--- a/branj
+++ b/branj
@@ -7,7 +7,7 @@ BRANJ_CONFIG_FILEPATH="${BRANJ_CONFIG_DIR}/.jiratoken"
 
 print_usage_doc() {
   cat <<USAGE_DOC
-Usage: `basename ${0}` [-s BRANCH_SUFFIX] JIRA_TICKET_NUMBER
+Usage: `basename ${0}` [-s BRANCH_SUFFIX] JIRA_TICKET_NUMBER [BASE_BRANCH]
 
 Automatically generates a branch name given a JIRA ticket number.
 
@@ -73,8 +73,9 @@ checkout_branch() {
 
   if [[ "${BRANCH_EXISTS}" -eq 0 ]]; then
     git checkout "${BRANCH_NAME}"
+    [[ ! -z "${BASE_BRANCH}" ]] && echo "Ignored base branch '${BASE_BRANCH}' since '${BRANCH_NAME}' already exists"
   else
-    git checkout -b "${BRANCH_NAME}"
+    git checkout -b "${BRANCH_NAME}" ${BASE_BRANCH:+ "${BASE_BRANCH}"}
   fi
 }
 
@@ -173,6 +174,7 @@ main() {
 
   JIRA_AUTH_STRING=$(read_from_config 1)
   JIRA_URL=$(read_from_config 2)
+  BASE_BRANCH="${2}"
 
   get_branch_name_from_jira "${JIRA_TICKET_NUMBER}"
 }


### PR DESCRIPTION
This works much in the same way that `git checkout` works: you can
specify a branch that you would like your new branch to be based off of
as a second arg.

```
$ # on branch 'skillless'
$ branj PM-1337 master
$ # created branch 'PM-1337-level-up' based off 'master'
```