### PR TITLE
Avoid extra dashes in branch names

### DIFF
--- a/branj
+++ b/branj
@@ -53,7 +53,7 @@ FIRST_TIME_SETUP_DOC
 generate_branch_name() {
   local TICKET_KEY="$(jq -r '.key' <(echo ${1}))"
   local TICKET_NAME="$(jq -r '.fields.summary' <(echo ${1}) | tr '[:upper:]' '[:lower:]')"
-  local BRANCH_NAME="$(echo ${TICKET_KEY}-${TICKET_NAME} | sed -E 's/[^A-Za-z0-9]/-/g;s/-{2,}/-/g')"
+  local BRANCH_NAME="$(echo ${TICKET_KEY}$(echo ${TICKET_NAME} | tr -cd '[a-zA-Z0-9] ' | sed -E 's/[^A-Za-z0-9]/-/g'))"
 
   if [[ -z "${BRANCH_SUFFIX}" ]]; then
     echo "${BRANCH_NAME}"

--- a/branj
+++ b/branj
@@ -53,7 +53,7 @@ FIRST_TIME_SETUP_DOC
 generate_branch_name() {
   local TICKET_KEY="$(jq -r '.key' <(echo ${1}))"
   local TICKET_NAME="$(jq -r '.fields.summary' <(echo ${1}) | tr '[:upper:]' '[:lower:]')"
-  local BRANCH_NAME="$(echo ${TICKET_KEY}$(echo ${TICKET_NAME} | tr -cd '[a-zA-Z0-9] ' | sed -E 's/[^A-Za-z0-9]/-/g'))"
+  local BRANCH_NAME="$(echo ${TICKET_KEY}-${TICKET_NAME} | sed -E 's/[^A-Za-z0-9]/-/g;s/-{2,}/-/g;s/-$//g')"
 
   if [[ -z "${BRANCH_SUFFIX}" ]]; then
     echo "${BRANCH_NAME}"


### PR DESCRIPTION
This takes the aggressive approach of wiping out all non-alphanumeric
characters from the branch name and just replacing all the spaces with
dashes.  This avoids weirdness like:

Fix thing (you know, the thing) -> `fix-thing--you-know--the-thing-`
Don't do this again -> `don-t-do-this-again`

Closes #6