### PR TITLE
PM-16948: Add -n option and fix idempotency

### DIFF
--- a/branj
+++ b/branj
@@ -78,7 +78,9 @@ checkout_branch() {
 
   if [[ "${BRANCH_EXISTS}" -eq 0 ]]; then
     git checkout "${BRANCH_NAME}"
-    [[ ! -z "${BASE_BRANCH}" ]] && echo "Ignored base branch '${BASE_BRANCH}' since '${BRANCH_NAME}' already exists"
+    if [[ -n "${BASE_BRANCH}" ]]; then
+      echo "Ignored base branch '${BASE_BRANCH}' since '${BRANCH_NAME}' already exists"
+    fi
   elif [[ "${RENAME_BRANCH}" ==  "true" ]]; then
     git branch -m "${BRANCH_NAME}"
   else

--- a/branj
+++ b/branj
@@ -7,12 +7,13 @@ BRANJ_CONFIG_FILEPATH="${BRANJ_CONFIG_DIR}/.jiratoken"
 
 print_usage_doc() {
   cat <<USAGE_DOC
-Usage: `basename ${0}`[-m] [-s BRANCH_SUFFIX] JIRA_TICKET_NUMBER [BASE_BRANCH]
+Usage: `basename ${0}` [-m] [-n] [-s BRANCH_SUFFIX] JIRA_TICKET_NUMBER [BASE_BRANCH]
 
 Automatically generates a branch name given a JIRA ticket number.
 
 Command line options:
 -m: rename the current branch instead of creating a new one (does not rename it upstream)
+-n: output the branch name only, without checking out or creating a branch
 -s BRANCH_SUFFIX: Add a suffix to the end of the created branch name
 
 Note that this script requires jq; run 'brew install jq' to install.
@@ -117,7 +118,11 @@ get_branch_name_from_jira() {
 
   case "${STATUS_CODE}" in
     200)
-      checkout_branch "${JSON_RESPONSE}"
+      if [[ "${NAME_ONLY}" == "true" ]]; then
+        generate_branch_name "${JSON_RESPONSE}"
+      else
+        checkout_branch "${JSON_RESPONSE}"
+      fi
       ;;
     401)
       print_unauthorized_message
@@ -156,13 +161,16 @@ parse_args() {
   JIRA_TICKET_NUMBER="${NON_OPTION_ARGS[0]}"
   BASE_BRANCH="${NON_OPTION_ARGS[1]}"
 
-  while getopts "ms:" OPTION; do
+  while getopts "mns:" OPTION; do
     case $OPTION in
       s)
         BRANCH_SUFFIX="${OPTARG}"
         ;;
       m)
         RENAME_BRANCH="true"
+        ;;
+      n)
+        NAME_ONLY="true"
         ;;
       \?)
         echo "Invalid option: -${OPTARG}" >&2


### PR DESCRIPTION
## Summary
- Add `-n` flag to output the generated branch name to stdout without checking out or creating a branch, enabling use by other CLI tools (e.g. git worktree creation)
- Fix a bug where branj exited with a non-zero exit code when the target branch already existed and no base branch was specified, caused by a short-circuit `[[ ]] && echo` pattern under `set -e`

## Test plan
- [x] Run `branj -n <ticket>` and verify it prints the branch name without switching branches
- [x] Run `branj <ticket>` twice in a row and verify both invocations exit 0
- [x] Run `branj <ticket> <base-branch>` when the branch already exists and verify the warning message still appears
- [x] Verify `-m` and `-s` flags still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)